### PR TITLE
Fix docker-compose-javawork.yml

### DIFF
--- a/docker-compose-javaworker.yml
+++ b/docker-compose-javaworker.yml
@@ -25,7 +25,9 @@ services:
       - back-tier
 
   worker:
-    build: ./worker/Dockerfile.j
+    build:
+      context: ./worker
+      dockerfile: Dockerfile.j
     networks:
       - back-tier
 


### PR DESCRIPTION
With docker-compose 1.10-rc1 build from this file was failing. Fix this by using the new build syntax with explicit `context` & `dockerfile`.