### PR TITLE
Update replicas to 1 in result service

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -46,7 +46,7 @@ services:
     depends_on:
       - db
     deploy:
-      replicas: 2
+      replicas: 1
       update_config:
         parallelism: 2
         delay: 10s


### PR DESCRIPTION
If a loadbalancer is used for this service, then socket.io will fail as the session will be created only in one container.